### PR TITLE
Remove warning from socket.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 ## KNOT Android library
 
+[![Build Status](https://travis-ci.org/CESARBR/knot-lib-android-source.svg?branch=master)](https://travis-ci.org/CESARBR/knot-lib-android-source)
+
 1. This lib is a part of KNOT solution (for more information: https://github.com/CESARBR) and it aims to provide an abstraction for Android applications to create IoT (Internet of Things) solutions using KNOT platform by HTTP and Socket protocols.
 
 ## knot-lib-android-source Goals

--- a/androidlibrary/build.gradle
+++ b/androidlibrary/build.gradle
@@ -23,7 +23,10 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.squareup.okhttp:okhttp:2.7.0'
     compile 'com.google.code.gson:gson:2.4'
-    compile 'com.github.nkzawa:socket.io-client:0.3.0'
+
+    compile ('com.github.nkzawa:socket.io-client:0.4.1') {
+        exclude group:'org.json', module:'json'
+    }
     compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.android.support:support-annotations:23.4.0'
     androidTestCompile 'com.android.support.test:runner:0.4'


### PR DESCRIPTION
- Avoid  warning by excluding duplicate org.json package